### PR TITLE
Add Package: openPMD-api

### DIFF
--- a/e4s/spack.yaml
+++ b/e4s/spack.yaml
@@ -55,6 +55,7 @@ spack:
   - hdf5
   - adios2
   - adios
+  - openpmd-api
   - darshan-runtime
   - darshan-util
   - veloc


### PR DESCRIPTION
Adds [openPMD-api](https://github.com/openPMD/openPMD-api) to pre-build software caches, a middle-ware library build on top of ADIOS1, ADIOS2 and HDF5 which is used in ECP-apps for domain-specific, best-practice I/O according to the [openPMD-standard](https://github.com/openPMD/openPMD-standard).

CC-ing @sameershende, @maherou, @chuckatkins, and @jwillenbring as per e-mail exchange.